### PR TITLE
Add custom red and green button styles

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -10,11 +10,17 @@ struct ContentView: View {
                 .imageScale(.large)
                 .foregroundColor(.accentColor)
             Text("This is a test of how to use Working Copy.")
-                        Text("Need pro version of Working Copy")
+            Text("Need pro version of Working Copy")
             Text("Need Swift Playground")
             // Added comment
             // Removed comment
             // Looks like changes are not working... =(
+
+            Button("Red Button") {}
+                .buttonStyle(RedButtonStyle())
+
+            Button("Green Button") {}
+                .buttonStyle(GreenButtonStyle())
         }
     }
 }

--- a/CustomButtonStyles.swift
+++ b/CustomButtonStyles.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+/// A button style that renders a red rounded rectangle background.
+struct RedButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .padding()
+            .background(RoundedRectangle(cornerRadius: 8).fill(Color.red))
+            .foregroundColor(.white)
+            .opacity(configuration.isPressed ? 0.7 : 1.0)
+    }
+}
+
+/// A button style that renders a green rounded rectangle background.
+struct GreenButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .padding()
+            .background(RoundedRectangle(cornerRadius: 8).fill(Color.green))
+            .foregroundColor(.white)
+            .opacity(configuration.isPressed ? 0.7 : 1.0)
+    }
+}


### PR DESCRIPTION
## Summary
- create `CustomButtonStyles.swift` defining `RedButtonStyle` and `GreenButtonStyle`
- show examples of those buttons in `ContentView`

## Testing
- `swift build` *(fails: no such module 'AppleProductTypes')*

------
https://chatgpt.com/codex/tasks/task_b_683a4d1389f883239cc350300f0b6335