### PR TITLE
Add CitiesListView inside scrollable ContentView

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -4,7 +4,8 @@ struct ContentView: View {
     @State private var showAlert = false
 
     var body: some View {
-        VStack {
+        ScrollView {
+            VStack(alignment: .center) {
             Text("Working Copy Tutorial")
                 .font(.title)
             HStack {
@@ -32,6 +33,7 @@ struct ContentView: View {
                 .buttonStyle(GreenButtonStyle())
             Spacer()
             BrowserBarView()
+            CitiesListView()
         }
     }
 }


### PR DESCRIPTION
## Summary
- wrap `ContentView`'s layout in a vertical `ScrollView`
- embed `CitiesListView` at the bottom of the content

## Testing
- `swift build` *(fails: no such module 'AppleProductTypes')*

------
https://chatgpt.com/codex/tasks/task_b_683bcc6c16d08323b3a05e7904c20b28